### PR TITLE
DEP Use carets instead of dev requirements and use phpunit 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ import:
 
 env:
   global:
-    - REQUIRE_EXTRA="silverstripe/versioned:1.x-dev"
+    - REQUIRE_EXTRA="silverstripe/versioned:^1"
     - PHPUNIT_SUITE="recipe-ccl"

--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,17 @@
     "homepage": "https://silverstripe.org",
     "license": "BSD-3-Clause",
     "require": {
+        "php": "^7.3 || ^8.0",
         "silverstripe/recipe-plugin": "^1",
-        "silverstripe/recipe-core": "4.x-dev",
-        "cwp/cwp-core": "2.x-dev",
-        "silverstripe/auditor": "2.x-dev",
-        "silverstripe/environmentcheck": "2.x-dev",
-        "silverstripe/hybridsessions": "2.x-dev"
+        "silverstripe/recipe-core": "^4",
+        "cwp/cwp-core": "^2",
+        "silverstripe/auditor": "^2",
+        "silverstripe/environmentcheck": "^2",
+        "silverstripe/hybridsessions": "^2"
     },
     "require-dev": {
-        "sminnee/phpunit": "^5.7"
+        "phpunit/phpunit": "^9.5",
+        "silverstripe/framework": "^4.10"
     },
     "extra": {
         "project-files": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,11 @@
 <phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
-    <testsuite name="recipe-ccl">
-        <directory>vendor/cwp/cwp-core/tests</directory>
-        <directory>vendor/silverstripe/auditor/tests</directory>
-        <directory>vendor/silverstripe/environmentcheck/tests</directory>
-        <directory>vendor/silverstripe/hybridsessions/tests</directory>
-        <directory>vendor/silverstripe/mimevalidator/tests</directory>
-    </testsuite>
+    <testsuites>
+        <testsuite name="recipe-ccl">
+            <directory>vendor/cwp/cwp-core/tests</directory>
+            <directory>vendor/silverstripe/auditor/tests</directory>
+            <directory>vendor/silverstripe/environmentcheck/tests</directory>
+            <directory>vendor/silverstripe/hybridsessions/tests</directory>
+            <directory>vendor/silverstripe/mimevalidator/tests</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/497

Now that CWP won't be getting regular releases via cow, it probably makes sense to change this to carets to support adhoc releases