### PR TITLE
MNT Require phpunit ^9.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "silverstripe/hybridsessions": "3.0.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "silverstripe/framework": "^5",
         "silverstripe/versioned": "^2"
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/39

Fixes --prefer-lowest build - https://github.com/silverstripe/recipe-ccl/actions/runs/4781385272/jobs/8499794952

Issue is that 9.5 will install sebastian/type:^2 - we need to install 9.6 so that we been sebastian/type^3

This has already been done on the hybridsessions module itself https://github.com/silverstripe/silverstripe-hybridsessions/blob/3.0/composer.json#L22

