### PR TITLE
MNT Require ^1.2 of silverstripe/versioned for dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "silverstripe/framework": "^4.10",
-        "silverstripe/versioned": "^1"
+        "silverstripe/versioned": "^1.2"
     },
     "extra": {
         "project-files": [


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/188

Fixes --prefer-lowest build where it needs Versioned::withVersionedMode() - https://github.com/silverstripe/recipe-ccl/actions/runs/7669056589/job/21047773503

Method was introduced in versioned 1.2.0 - https://github.com/silverstripe/silverstripe-versioned/commit/32dcc4d34fa3490dfa4b1dd877448673176ca236